### PR TITLE
Use DateTime instead of String

### DIFF
--- a/bin/tadd
+++ b/bin/tadd
@@ -17,7 +17,7 @@ portal.restore_session
 
 if portal.need_login?
   print 'ユーザID: '
-  username = gets.chop
+  username = STDIN.gets.chop
   print 'パスワード: '
   password = STDIN.noecho(&:gets).chop
   puts

--- a/bin/tadd
+++ b/bin/tadd
@@ -4,6 +4,7 @@
 require 'dotenv'
 require 'pp'
 require 'io/console'
+require 'date'
 require './kut_portal'
 
 if ARGV.size < 6
@@ -31,6 +32,12 @@ end
 subject, summary, date, started, finished, rest_hours = *ARGV
 summary = :"#{summary}"
 
-unless portal.add_ta_work_record(subject, summary, date, started, finished, rest_hours)
-  puts '勤務記録追加失敗!'
-end
+res = portal.add_ta_work_record(
+  subject,
+  summary,
+  Date.parse(date),
+  DateTime.parse(started),
+  DateTime.parse(finished),
+  DateTime.parse(rest_hours))
+
+puts '勤務記録追加失敗!' unless res

--- a/kut_portal.rb
+++ b/kut_portal.rb
@@ -83,23 +83,31 @@ class KUTPortal
     keys = %i(date summary started finished rest_hours total_hours)
     Util.table_rows_to_records(tbl_rows, *keys)
   end
-
+  
   def add_ta_work_record(subject_name, summary, date, started, finished, rest_hours)
     ta_works(subject_name)
     works_form = @agent.page.forms[0]
     add_btn = works_form.button_with(value: /新規追加/)
     works_form.click_button(add_btn) # 科目勤務記録登録に遷移
 
-    summaries = %w(①授業補助 ②授業準備 ③資料作成 ④その他 ①②授業補助と授業準備 ①③授業補助と資料作成)
-
     form = @agent.page.forms[0]
-    form['ctl00$phContents$TaWorkEdit1$ctlWorkDate$txtDate'] = date
-    form['ctl00$phContents$TaWorkEdit1$ctlStartTime$txtHour'],
-      form['ctl00$phContents$TaWorkEdit1$ctlStartTime$txtMinute'] = started.split(':')
-    form['ctl00$phContents$TaWorkEdit1$ctlEndTime$txtHour'],
-      form['ctl00$phContents$TaWorkEdit1$ctlEndTime$txtMinute'] = finished.split(':')
-    form['ctl00$phContents$TaWorkEdit1$ctlRestTime$txtHour'],
-      form['ctl00$phContents$TaWorkEdit1$ctlRestTime$txtMinute'] = rest_hours.split(':')
+
+    # 日付
+    form['ctl00$phContents$TaWorkEdit1$ctlWorkDate$txtDate'] = date.strftime('%Y/%m/%d')
+
+    # 開始時間
+    form['ctl00$phContents$TaWorkEdit1$ctlStartTime$txtHour'] = started.strftime('%H')
+    form['ctl00$phContents$TaWorkEdit1$ctlStartTime$txtMinute'] = started.strftime('%M')
+
+    # 終了時間
+    form['ctl00$phContents$TaWorkEdit1$ctlEndTime$txtHour'] = finished.strftime('%H')
+    form['ctl00$phContents$TaWorkEdit1$ctlEndTime$txtMinute'] = finished.strftime('%M')
+
+    # 休憩時間
+    form['ctl00$phContents$TaWorkEdit1$ctlRestTime$txtHour'] = rest_hours.strftime('%H')
+    form['ctl00$phContents$TaWorkEdit1$ctlRestTime$txtMinute'] = rest_hours.strftime('%M')
+
+    # 名目
     form['ctl00$phContents$TaWorkEdit1$ctlWorkDetail$ddlWorkDetail'] = TA_WORK_SUMMARIES[summary]
 
     form.click_button(form.button_with(value: /登録/))


### PR DESCRIPTION
This pull request allows to specify more user-friendly arguments of `./tadd` command.

**Before**
`./tadd` didn't accept command as follows:

```
./tadd コンピュータリテラシ support 5/24 8:50 10:20 0:0
```

Because KUT Portal system can't accept date: `5/14`
So you need to write command as follows:

```
./tadd コンピュータリテラシ support 2016/5/24 8:50 10:20 0:0
```

**After**
`./tadd` will accept shorter date or time arguments as follows.

```
./tadd コンピュータリテラシ support 5/24 8:50 10:20 0:0
```
